### PR TITLE
Fixed: Devcontainer Images

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,11 @@
         "DavidAnson.vscode-markdownlint",
         "Gruntfuggly.todo-tree",
         "PKief.material-icon-theme",
+        "SonarSource.sonarlint-vscode",
         "Tyriar.sort-lines",
         "bradzacher.vscode-copy-filename",
         "charliermarsh.ruff",
         "foxundermoon.shell-format",
-        "ms-python.python",
         "ms-vscode.live-server",
         "streetsidesoftware.code-spell-checker",
         "usernamehw.errorlens"
@@ -80,7 +80,7 @@
       }
     }
   },
-  "image": "mcr.microsoft.com/devcontainers/python",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node",
   "mounts": [
     "source=${localWorkspaceFolder}/snippets,target=${containerWorkspaceFolder}/.vscode,type=bind,consistency=cached"
   ],


### PR DESCRIPTION
This pull request includes changes to the `.devcontainer/devcontainer.json` file, focusing on updating the development environment configuration. The most important changes include the addition and removal of Visual Studio Code extensions and switching the base image for the development container.

Changes to Visual Studio Code extensions:

* Added the `SonarSource.sonarlint-vscode` extension to the list of installed extensions.
* Removed the `ms-python.python` extension from the list of installed extensions.

Changes to the development container configuration:

* Changed the base image from `mcr.microsoft.com/devcontainers/python` to `mcr.microsoft.com/devcontainers/javascript-node`.